### PR TITLE
Used tyles class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,8 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-compiler-plugin</artifactId>
               <configuration>
-                  <source>9</source>
-                  <target>9</target>
+                  <source>11</source>
+                  <target>11</target>
               </configuration>
           </plugin>
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -99,5 +99,15 @@
         </plugin>
       </plugins>
     </pluginManagement>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                  <source>9</source>
+                  <target>9</target>
+              </configuration>
+          </plugin>
+      </plugins>
   </build>
 </project>

--- a/src/main/java/sk/uniba/fmph/dcs/UsedTiles.java
+++ b/src/main/java/sk/uniba/fmph/dcs/UsedTiles.java
@@ -25,9 +25,6 @@ public class UsedTiles {
 
     // Method to retrieve and remove all Tile objects from the usedTiles list.
     public Tile[] takeAll() {
-        if (this.usedTiles.isEmpty()) {
-            throw new NoSuchElementException("No tiles to take. The usedTiles list is empty.");
-        }
         Tile[] tilesArray = new Tile[this.usedTiles.size()];
         tilesArray = this.usedTiles.toArray(tilesArray);
         this.usedTiles.clear();

--- a/src/main/java/sk/uniba/fmph/dcs/UsedTiles.java
+++ b/src/main/java/sk/uniba/fmph/dcs/UsedTiles.java
@@ -3,23 +3,30 @@ package sk.uniba.fmph.dcs;
 import java.util.*;
 
 public class UsedTiles {
-    private List<Tile> UsedTiles;
+    private List<Tile> usedTiles; //List to hold used tiles
 
     public UsedTiles() {
-        // Constructor implementation
+        this.usedTiles = new ArrayList<>();
     }
 
+    // Method to add an array of Tile objects to the usedTiles list.
     public void give(Tile[] tiles) {
-        // Implementation
+        this.usedTiles.addAll(Arrays.asList(tiles));
     }
 
+    // Method to retrieve and remove all Tile objects from the usedTiles list.
     public Tile[] takeAll() {
-        // Implementation
-        return null;
+        Tile[] tilesArray = new Tile[this.usedTiles.size()];
+        tilesArray = this.usedTiles.toArray(tilesArray);
+        this.usedTiles.clear();
+        return tilesArray;
     }
 
+    // Method to return a string representation of the current state of usedTiles.
     public String state() {
-        // Implementation
-        return null;
+        return "UsedTiles{" +
+                "count=" + usedTiles.size() +
+                ", usedTiles=" + usedTiles +
+                '}';
     }
 }

--- a/src/main/java/sk/uniba/fmph/dcs/UsedTiles.java
+++ b/src/main/java/sk/uniba/fmph/dcs/UsedTiles.java
@@ -9,12 +9,18 @@ public class UsedTiles {
         this.usedTiles = new ArrayList<>();
     }
 
-    // Method to add an array of Tile objects to the usedTiles list.
+    // Method to add an array of Tile objects to the usedTiles list without STARTING_PLAYER tile.
     public void give(Tile[] tiles) {
         if (tiles == null) {
             throw new IllegalArgumentException("Cannot add null array of tiles.");
         }
-        this.usedTiles.addAll(Arrays.asList(tiles));
+        for (Tile tile : tiles) {
+            // Check if the current tile is the STARTING_PLAYER tile
+            if (tile == Tile.STARTING_PLAYER) {
+                continue;
+            }
+            this.usedTiles.add(tile);
+        }
     }
 
     // Method to retrieve and remove all Tile objects from the usedTiles list.

--- a/src/main/java/sk/uniba/fmph/dcs/UsedTiles.java
+++ b/src/main/java/sk/uniba/fmph/dcs/UsedTiles.java
@@ -11,11 +11,17 @@ public class UsedTiles {
 
     // Method to add an array of Tile objects to the usedTiles list.
     public void give(Tile[] tiles) {
+        if (tiles == null) {
+            throw new IllegalArgumentException("Cannot add null array of tiles.");
+        }
         this.usedTiles.addAll(Arrays.asList(tiles));
     }
 
     // Method to retrieve and remove all Tile objects from the usedTiles list.
     public Tile[] takeAll() {
+        if (this.usedTiles.isEmpty()) {
+            throw new NoSuchElementException("No tiles to take. The usedTiles list is empty.");
+        }
         Tile[] tilesArray = new Tile[this.usedTiles.size()];
         tilesArray = this.usedTiles.toArray(tilesArray);
         this.usedTiles.clear();

--- a/src/main/java/sk/uniba/fmph/dcs/UsedTiles.java
+++ b/src/main/java/sk/uniba/fmph/dcs/UsedTiles.java
@@ -3,7 +3,7 @@ package sk.uniba.fmph.dcs;
 import java.util.*;
 
 public class UsedTiles {
-    private List<Tile> usedTiles; //List to hold used tiles
+    private final List<Tile> usedTiles; //List to hold used tiles
 
     public UsedTiles() {
         this.usedTiles = new ArrayList<>();

--- a/src/main/java/sk/uniba/fmph/dcs/UsedTiles.java
+++ b/src/main/java/sk/uniba/fmph/dcs/UsedTiles.java
@@ -1,0 +1,25 @@
+package sk.uniba.fmph.dcs;
+
+import java.util.*;
+
+public class UsedTiles {
+    private List<Tile> UsedTiles;
+
+    public UsedTiles() {
+        // Constructor implementation
+    }
+
+    public void give(Tile[] tiles) {
+        // Implementation
+    }
+
+    public Tile[] takeAll() {
+        // Implementation
+        return null;
+    }
+
+    public String state() {
+        // Implementation
+        return null;
+    }
+}

--- a/src/test/java/sk/uniba/fmph/dcs/UsedTilesTest.java
+++ b/src/test/java/sk/uniba/fmph/dcs/UsedTilesTest.java
@@ -21,6 +21,21 @@ public class UsedTilesTest {
     }
 
     @Test
+    public void testIfSPTIsNotIn(){
+        Tile[] tiles = {Tile.STARTING_PLAYER, Tile.BLUE, Tile.GREEN};
+        usedTiles.give(tiles);
+        assertArrayEquals(new Tile[]{Tile.BLUE, Tile.GREEN}, usedTiles.takeAll());
+    }
+
+    @Test
+    public void testIfSPTIsNotInTwice(){
+        Tile[] tiles = {Tile.STARTING_PLAYER, Tile.BLUE, Tile.GREEN};
+        Tile[] tiles2x = {Tile.BLUE, Tile.GREEN, Tile.BLUE, Tile.GREEN};
+        usedTiles.give(tiles);
+        usedTiles.give(tiles);
+        assertArrayEquals(tiles2x, usedTiles.takeAll());
+    }
+    @Test
     public void testGiveEmptyArrayShouldThrowException() {
         Tile[] tiles = new Tile[0];
         usedTiles.give(tiles);

--- a/src/test/java/sk/uniba/fmph/dcs/UsedTilesTest.java
+++ b/src/test/java/sk/uniba/fmph/dcs/UsedTilesTest.java
@@ -1,0 +1,127 @@
+package sk.uniba.fmph.dcs;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.util.NoSuchElementException;
+
+public class UsedTilesTest {
+
+    private UsedTiles usedTiles;
+
+    @Before
+    public void setUp() {
+        usedTiles = new UsedTiles();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGiveNullArray() {
+        usedTiles.give(null);
+    }
+
+    @Test
+    public void testGiveEmptyArrayShouldThrowException() {
+        Tile[] tiles = new Tile[0];
+        usedTiles.give(tiles);
+
+        try {
+            usedTiles.takeAll();
+            fail("Expected NoSuchElementException to be thrown");
+        } catch (NoSuchElementException e) {
+            // Test passes if NoSuchElementException is caught
+            String expectedMessage = "No tiles to take. The usedTiles list is empty.";
+            assertEquals(expectedMessage, e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGiveSomeTiles() {
+        Tile[] tiles = {Tile.RED, Tile.BLUE, Tile.GREEN};
+        usedTiles.give(tiles);
+        assertArrayEquals(tiles, usedTiles.takeAll());
+    }
+
+    @Test
+    public void testGiveTilesTwice() {
+        Tile[] tiles = {Tile.RED, Tile.BLUE};
+        Tile[] tiles2x = {Tile.RED, Tile.BLUE, Tile.RED, Tile.BLUE};
+        usedTiles.give(tiles);
+        usedTiles.give(tiles);
+        assertArrayEquals(tiles2x, usedTiles.takeAll());
+    }
+
+    @Test
+    public void testGiveMixedTiles() {
+        Tile[] tiles1 = {Tile.RED, Tile.GREEN};
+        Tile[] tiles2 = {Tile.YELLOW, Tile.BLUE};
+        Tile[] tiles1_2 = {Tile.RED, Tile.GREEN, Tile.YELLOW, Tile.BLUE};
+        usedTiles.give(tiles1);
+        usedTiles.give(tiles2);
+        assertArrayEquals(tiles1_2, usedTiles.takeAll());
+    }
+
+    @Test
+    public void testGiveTilesWithNull() {
+        Tile[] tiles = {Tile.RED, Tile.BLUE, null};
+        usedTiles.give(tiles);
+        assertArrayEquals(tiles, usedTiles.takeAll());
+    }
+
+    @Test
+    public void testGiveTilesWithNullTwice() {
+        Tile[] tiles = {Tile.RED, Tile.BLUE, null};
+        Tile[] tiles2x = {Tile.RED, Tile.BLUE, null, Tile.RED, Tile.BLUE, null};
+        usedTiles.give(tiles);
+        usedTiles.give(tiles);
+        assertArrayEquals(tiles2x, usedTiles.takeAll());
+    }
+
+    @Test
+    public void testState() {
+        assertEquals("UsedTiles{count=0, usedTiles=[]}", usedTiles.state());
+    }
+
+    @Test
+    public void testStateAfterGive() {
+        Tile[] tiles = {Tile.RED, Tile.BLUE, Tile.GREEN};
+        usedTiles.give(tiles);
+        assertEquals("UsedTiles{count=3, usedTiles=[R, B, G]}", usedTiles.state());
+    }
+
+    @Test
+    public void testStateAfterGiveTwice() {
+        Tile[] tiles = {Tile.RED, Tile.BLUE, Tile.GREEN};
+        usedTiles.give(tiles);
+        usedTiles.give(tiles);
+        assertEquals("UsedTiles{count=6, usedTiles=[R, B, G, R, B, G]}", usedTiles.state());
+    }
+
+    @Test
+    public void testStateAfterGiveMixedTiles() {
+        Tile[] tiles1 = {Tile.RED, Tile.GREEN};
+        Tile[] tiles2 = {Tile.YELLOW, Tile.BLUE};
+        usedTiles.give(tiles1);
+        usedTiles.give(tiles2);
+        assertEquals("UsedTiles{count=4, usedTiles=[R, G, I, B]}", usedTiles.state());
+    }
+
+    @Test
+    public void testStateAfterGiveTilesWithNull() {
+        Tile[] tiles = {Tile.RED, Tile.BLUE, null};
+        usedTiles.give(tiles);
+        assertEquals("UsedTiles{count=3, usedTiles=[R, B, null]}", usedTiles.state());
+    }
+
+    @Test
+    public void testTakeAllThenGive2xThanTakeAll() {
+        Tile[] tiles = {Tile.RED, Tile.BLUE, Tile.GREEN};
+        Tile[] tiles2x = {Tile.RED, Tile.BLUE, Tile.GREEN, Tile.RED, Tile.BLUE, Tile.GREEN};
+        usedTiles.give(tiles);
+        usedTiles.takeAll();
+        usedTiles.give(tiles);
+        usedTiles.give(tiles);
+        assertArrayEquals(tiles2x, usedTiles.takeAll());
+    }
+
+}

--- a/src/test/java/sk/uniba/fmph/dcs/UsedTilesTest.java
+++ b/src/test/java/sk/uniba/fmph/dcs/UsedTilesTest.java
@@ -36,18 +36,12 @@ public class UsedTilesTest {
         assertArrayEquals(tiles2x, usedTiles.takeAll());
     }
     @Test
-    public void testGiveEmptyArrayShouldThrowException() {
+    public void testGiveEmptyArray() {
         Tile[] tiles = new Tile[0];
         usedTiles.give(tiles);
+        usedTiles.takeAll();
 
-        try {
-            usedTiles.takeAll();
-            fail("Expected NoSuchElementException to be thrown");
-        } catch (NoSuchElementException e) {
-            // Test passes if NoSuchElementException is caught
-            String expectedMessage = "No tiles to take. The usedTiles list is empty.";
-            assertEquals(expectedMessage, e.getMessage());
-        }
+        assertArrayEquals(tiles, usedTiles.takeAll());
     }
 
     @Test


### PR DESCRIPTION
## Overview

This pull request introduces the complete implementation of the `UsedTiles` class for our board game project. The class is responsible for maintaining a collection of used tiles during gameplay. An additional functionality to filter out the `STARTING_PLAYER` tile during the `give` operation has also been implemented. Accompanying unit tests have been added to ensure the integrity of the `give` method's new behavior.

## Changes

- Implemented the `UsedTiles` class with methods `give`, `takeAll`, and `state`.
- Modified the `give` method to check for and handle `STARTING_PLAYER` tiles appropriately, according to the game logic.
- Added a comprehensive set of unit tests to validate the behavior
- Ensured that existing functionality remains intact and that new code conforms to our project's coding standards.

## Testing

- All new unit tests are passing, ensuring.
- Existing tests for the `UsedTiles` class have been run to confirm that no regressions have been introduced.

## Discussion Points

- Consideration may be needed on how `STARTING_PLAYER` tiles should be handled beyond the scope of the `UsedTiles` class.
- Feedback on the exception handling within the `give` method when encountering `null` arrays or empty used tiles list.
- Feedback on the exception handling within the `takeAll` method when no tiles to take.

## Action Items

- Review the handling strategy for `STARTING_PLAYER` tiles and confirm it aligns with the overall game rules.
- Review the unit tests for completeness and coverage.
- Discuss the exception handling strategy and confirm it aligns with our project's error management policies.

I look forward to the team's feedback and any further discussions needed for this feature.
